### PR TITLE
Ignore case in Record.matches

### DIFF
--- a/src/main/java/com/trigonic/jrobotx/Record.java
+++ b/src/main/java/com/trigonic/jrobotx/Record.java
@@ -49,7 +49,7 @@ public class Record {
 		
 		userAgentString = userAgentString.toLowerCase();
 		for (String userAgent : userAgents) {
-			if (userAgent.equals(ANY) || userAgentString.contains(userAgent)) {
+			if (userAgent.equals(ANY) || userAgentString.contains(userAgent.toLowerCase())) {
 				result = true;
 				break;
 			}

--- a/src/test/java/com/trigonic/jrobotx/RecordTest.java
+++ b/src/test/java/com/trigonic/jrobotx/RecordTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.*;
 public class RecordTest {
     @Test
     public void test() {
-        Set<String> userAgents = new HashSet<String>(Arrays.asList("netscape", "mozilla"));
+        Set<String> userAgents = new HashSet<String>(Arrays.asList("netscape", "Mozilla"));
         List<String[]> rules = new ArrayList<String[]>();
         rules.add(new String[] {"Disallow", ""});
         rules.add(new String[] {"Disallow", "/foo/bar/"});


### PR DESCRIPTION
This change ensures that case is ignored when determining whether a given `Record` matches against a specified user agent.

For example, a `Record` representing the following example:

```
User-agent: Mozilla
Disallow: /
```

will return `false` for `record.matches("Mozilla")`, since the current logic lowercases the user agent passed into the `matches` method, but does not lowercase the user agent for the record itself.
